### PR TITLE
feat: OK/NGリストのキャッシュ読み込みロジックを改善

### DIFF
--- a/src/app/tools/vrchat-introduction-card/page.tsx
+++ b/src/app/tools/vrchat-introduction-card/page.tsx
@@ -184,11 +184,19 @@ function VRChatCardGenerator() {
     }
 
     if (cache.interactions) {
-      const validLabels = Object.keys(translations.ja.okNgDefaults);
-      const filteredInteractions = cache.interactions.filter(item => 
-        item.isCustom || validLabels.includes(item.label)
-      );
-      setInteractions(filteredInteractions);
+      const defaultKeys = Object.keys(translations.ja.okNgDefaults);
+      
+      // Restore default items, preserving their order and marks from cache
+      const restoredDefaults = defaultKeys.map(key => {
+        const cachedItem = cache.interactions.find(item => !item.isCustom && item.label === key);
+        return cachedItem || { label: key, mark: '-', isCustom: false };
+      });
+
+      // Restore custom items from cache
+      const customItems = cache.interactions.filter(item => item.isCustom);
+
+      // Combine them
+      setInteractions([...restoredDefaults, ...customItems]);
     }
 
     if (cache.backgroundType) setBackgroundType(cache.backgroundType)

--- a/src/app/tools/vrchat-introduction-card/page.tsx
+++ b/src/app/tools/vrchat-introduction-card/page.tsx
@@ -184,11 +184,20 @@ function VRChatCardGenerator() {
     }
 
     if (cache.interactions) {
-      const validLabels = Object.keys(translations.ja.okNgDefaults);
-      const filteredInteractions = cache.interactions.filter(item => 
-        item.isCustom || validLabels.includes(item.label)
-      );
-      setInteractions(filteredInteractions);
+      const interactionsCache = cache.interactions;
+      const defaultKeys = Object.keys(translations.ja.okNgDefaults);
+      
+      // Restore default items, preserving their order and marks from cache
+      const restoredDefaults = defaultKeys.map(key => {
+        const cachedItem = interactionsCache.find(item => !item.isCustom && item.label === key);
+        return cachedItem || { label: key, mark: '-', isCustom: false };
+      });
+
+      // Restore custom items from cache
+      const customItems = interactionsCache.filter(item => item.isCustom);
+
+      // Combine them
+      setInteractions([...restoredDefaults, ...customItems]);
     }
 
     if (cache.backgroundType) setBackgroundType(cache.backgroundType)


### PR DESCRIPTION
キャッシュからOK/NGリストを復元する際のロジックを修正しました。

これまでの実装では、キャッシュに存在する項目のみが復元されていました。この変更により、デフォルトの項目が常にすべて表示され、キャッシュに保存されている値があればそれが適用され、なければデフォルト値が設定されるようになります。また、ユーザーが追加したカスタム項目も正しく保持されます。

これにより、ユーザーが項目を意図せず失うことを防ぎ、より安定した動作を提供します。